### PR TITLE
update to chem class survey for mysql v5.7.34

### DIFF
--- a/R/rampQueryHelper.R
+++ b/R/rampQueryHelper.R
@@ -224,15 +224,6 @@ chemicalClassSurveyRampIdsConn <- function(mets, pop, conn) {
   metStr <- paste(mets, collapse = "','")
   metStr <- paste("'" ,metStr, "'", sep = "")
 
-
-  print("")
-  print("")
-  print("")
-  print("HEY               NEW  CHEM CLASS SURVEY!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-  print("")
-  print("")
-  print("")
-
   sql <- paste("select distinct a.ramp_id, b.sourceId, group_concat(distinct b.commonName order by b.commonName asc separator '; ') as common_names, a.class_level_name, a.class_name, a.source from metabolite_class a, source b
           where b.rampId = a.ramp_id and b.sourceId in (",metStr,")
                group by b.rampId, a.class_level_name, a.class_name, a.source")
@@ -262,7 +253,7 @@ chemicalClassSurveyRampIdsConn <- function(mets, pop, conn) {
   popStr <- paste("'" ,popStr, "'", sep = "")
 
   sql <- paste("select distinct a.ramp_id, b.sourceId, group_concat(distinct b.commonName order by b.commonName asc separator '; ') as common_names, a.class_level_name, a.class_name, a.source from metabolite_class a, source b
-          where b.rampId = a.ramp_id and b.sourceId in (",popStr,") group by b.rampId, a.class_level_name, a.class_name, a.source")
+          where b.rampId = a.ramp_id and b.sourceId in (",popStr,") group by a.ramp_Id, b.sourceId, a.class_level_name, a.class_name, a.source")
 
   popData <- RMariaDB::dbGetQuery(conn, sql)
 
@@ -332,7 +323,8 @@ chemicalClassSurveyRampIdsFullPopConn <- function(mets, conn) {
 
   sql <- paste("select distinct a.ramp_id, b.sourceId, group_concat(distinct b.commonName order by b.commonName asc separator '; ') as common_names, a.class_level_name, a.class_name, a.source as source from metabolite_class a, source b
           where b.rampId = a.ramp_id and b.sourceId in (",metStr,")
-               group by b.rampId, a.class_level_name, a.class_name, a.source")
+               group by a.ramp_Id, b.sourceId, a.class_level_name, a.class_name, a.source")
+
 
   metsData <- RMariaDB::dbGetQuery(conn, sql)
 


### PR DESCRIPTION
I made updates to Chemical Class Survey sql to allow compatibility with mysql 5.7.34 and beyond. This patch in dev should be merged into the master branch. Thanks.