### PR TITLE
Patch chem class sql

### DIFF
--- a/R/rampQueryHelper.R
+++ b/R/rampQueryHelper.R
@@ -868,7 +868,7 @@ chemicalClassSurveyRampIdsFullPopConn <- function(mets, conn, inferIdMapping=TRU
   } else {
     sql = paste("select distinct c.ramp_id, c.class_source_id, group_concat(distinct s.commonName order by s.commonName asc separator '; ') as common_names,
                 c.class_level_name, c.class_name, c.source, count(distinct(c.class_source_id)) as directIdClassHits from metabolite_class c, source s
-          where c.class_source_id in (",metStr,") and s.sourceId = c.class_source_id group by c.class_source_id, c.class_level_name, c.class_name")
+          where c.class_source_id in (",metStr,") and s.sourceId = c.class_source_id group by c.class_source_id, c.class_level_name, c.class_name, c.source, c.ramp_id")
   }
 
   metsData <- RMariaDB::dbGetQuery(conn, sql)

--- a/R/rampQueryHelper.R
+++ b/R/rampQueryHelper.R
@@ -719,7 +719,7 @@ chemicalClassSurveyRampIdsConn <- function(mets, pop, conn, inferIdMapping=TRUE)
                  c.class_level_name, c.class_name, c.source as source, count(distinct(c.class_source_id)) as directIdClassHits
                  from metabolite_class c, source s
                  where c.class_source_id in (",metStr,") and s.sourceId = c.class_source_id
-                 group by c.class_source_id, c.class_level_name, c.class_name")
+                 group by c.class_source_id, c.class_level_name, c.class_name, c.source, c.ramp_id")
   }
 
   metsData <- RMariaDB::dbGetQuery(conn, sql)
@@ -766,7 +766,7 @@ chemicalClassSurveyRampIdsConn <- function(mets, pop, conn, inferIdMapping=TRUE)
                  count(distinct(c.class_source_id)) as directIdClassHits
                  from metabolite_class c
                  where c.class_source_id in (",popStr,")
-                 group by c.class_source_id, c.class_level_name, c.class_name")
+                 group by c.class_source_id, c.class_level_name, c.class_name, c.source, c.ramp_id")
   }
 
   # ("select distinct c.ramp_id, c.class_source_id, group_concat(distinct s.commonName order by s.commonName asc separator '; ') as common_names,


### PR DESCRIPTION
The chem class survey methods needed to have the sql update to add selected columns to the group by. MySQL 8.x having the default 'sql_mode' variable setting include 'ONLY_FULL_GROUP_BY' did not handle the original sql. 