### PR TITLE
clean up ontology functions

### DIFF
--- a/R/OntologyQueryFunctions.R
+++ b/R/OntologyQueryFunctions.R
@@ -3,6 +3,8 @@
 #' @param mets a vector of metabolites or a metabolites delimited by new line character
 #' @param namesOrIds specify the type of given data
 #' @param includeRaMPids whether or not to include RaMP ids in the output (TRUE/FALSE)
+#' @param min_ontology_size the minimum number of metabolites in an ontology for it to be included in results. Default is 1,000
+#' @param max_ontology_size the maximum number of metabolites in an ontology for it to be included in results. Default is Inf
 #' @param db a RaMP database object
 #' @return dataframe that contains searched ontology from given metabolites
 #'
@@ -12,7 +14,7 @@
 #' getOntoFromMeta(mets = "hmdb:HMDB0071437", db=rampDB)
 #' }
 #' @export
-getOntoFromMeta <- function(mets, namesOrIds = "ids", includeRaMPids = FALSE, db = RaMP()) {
+getOntoFromMeta <- function(mets, namesOrIds = "ids", includeRaMPids = FALSE, min_ontology_size = 1E3, max_ontology_size = Inf, db = RaMP()) {
   if (!(namesOrIds %in% c("ids", "names"))) {
     stop("Specifiy the type of given data to 'ids' or 'names'")
   }
@@ -51,10 +53,15 @@ getOntoFromMeta <- function(mets, namesOrIds = "ids", includeRaMPids = FALSE, db
 
   rampid <- unique(df$rampId)
 
-  df2 <- db@api$getOntologiesForRampIDs(rampIds = rampid)
+  temp_ontologies_df <- getOntologies() %>%
+    dplyr::filter(.data$metCount <= max_ontology_size,
+                  .data$metCount > min_ontology_size)
+
+  df2 <- db@api$getOntologiesForRampIDs(rampIds = rampid) %>%
+    dplyr::filter(.data$rampOntologyId %in% temp_ontologies_df$rampOntologyId)
 
   if (nrow(df2) == 0) {
-    message("No searching result because these metabolites are not linked to ontology")
+    message("No searching result because these metabolites are not linked to ontology in search parameters")
     return(NULL)
   }
 
@@ -89,6 +96,9 @@ getOntoFromMeta <- function(mets, namesOrIds = "ids", includeRaMPids = FALSE, db
 
 #' function that query database to find mets in given ontologies
 #' @param ontology a vector of ontology or ontologies delimited by new line character
+#' @param min_ontology_size the minimum number of metabolites in an ontology for it to be included in results. Default is 1,000
+#' @param max_ontology_size the maximum number of metabolites in an ontology for it to be included in results. Default is Inf
+#' @param curate filter searchable ontologies to only those visible to filter by when searching the HMDB website. Primarily for front-end UI use.
 #' @param db a RaMP database object
 #' @return dataframe that contains searched mets from given ontology
 #' @examples
@@ -98,8 +108,9 @@ getOntoFromMeta <- function(mets, namesOrIds = "ids", includeRaMPids = FALSE, db
 #' new.metabolites <- RaMP::getMetaFromOnto(db = rampDB, ontology = ontologies.of.interest)
 #' }
 #' @importFrom rlang .data
+#' @importFrom magrittr %>%
 #' @export
-getMetaFromOnto <- function(ontology, db = RaMP()) {
+getMetaFromOnto <- function(ontology, min_ontology_size = 1E3, max_ontology_size = Inf, curate = F, db = RaMP()) {
   print("Retreiving Metabolites for input ontology terms.")
   now <- proc.time()
   if (is.character(ontology)) {
@@ -118,11 +129,39 @@ getMetaFromOnto <- function(ontology, db = RaMP()) {
 
   list_ontology <- unique(list_ontology)
 
-  allontos <- getOntologies(db = db)
-  matched_ontos <- unlist(lapply(
-    list_ontology,
-    function(x) grep(paste0("^", x, "$"), allontos$commonName)
-  ))
+  allontos <- getOntologies(db = db) %>%
+    dplyr::filter(.data$metCount <= max_ontology_size,
+                  .data$metCount > min_ontology_size)
+
+  #This if statement is meant for use with the front end.
+  #The idea is to limit the ontologies searchable in the RaMP UI to be the same ones HMDB lets the user filter by on their website.
+  #This is hard-coded as a filter here and will need to be updated manually in the current form.
+  #The default 'curate' argument should be false.
+  #Adam 10/3/2024
+  if (curate) {
+    allontos <- allontos %>% dplyr::filter(.data$commonName %in% c('Blood',
+                                                'Urine',
+                                                'Saliva',
+                                                'Cerebrospinal fluid',
+                                                'Feces',
+                                                'Sweat',
+                                                'Breast milk',
+                                                'Bile',
+                                                'Amniotic fluid',
+                                                'Exogenous',
+                                                'Endogenous',
+                                                'Food',
+                                                'Plant',
+                                                'Microbe',
+                                                'Cosmetic',
+                                                'Drug',
+                                                'Cell membrane',
+                                                'Cytoplasm',
+                                                'Nucleus',
+                                                'Mitochondria'))
+  }
+
+  matched_ontos <- list_ontology[list_ontology %in% allontos$commonName]
 
   # Only proceed if df has anything returned
   if (length(matched_ontos) > 0) {
@@ -141,7 +180,7 @@ getMetaFromOnto <- function(ontology, db = RaMP()) {
 
     return(mdf_final)
   } else {
-    warning("The input ontology terms were not found in RaMP.\nRun the getOntologies() function to see available ontology terms.")
+    warning("The input ontology terms were not found in RaMP within input parameters.\nRun the getOntologies() function to see available ontology terms.")
     return(NA)
   }
 }

--- a/man/getMetaFromOnto.Rd
+++ b/man/getMetaFromOnto.Rd
@@ -4,10 +4,22 @@
 \alias{getMetaFromOnto}
 \title{function that query database to find mets in given ontologies}
 \usage{
-getMetaFromOnto(ontology, db = RaMP())
+getMetaFromOnto(
+  ontology,
+  min_ontology_size = 1000,
+  max_ontology_size = Inf,
+  curate = F,
+  db = RaMP()
+)
 }
 \arguments{
 \item{ontology}{a vector of ontology or ontologies delimited by new line character}
+
+\item{min_ontology_size}{the minimum number of metabolites in an ontology for it to be included in results. Default is 1,000}
+
+\item{max_ontology_size}{the maximum number of metabolites in an ontology for it to be included in results. Default is Inf}
+
+\item{curate}{filter searchable ontologies to only those visible to filter by when searching the HMDB website. Primarily for front-end UI use.}
 
 \item{db}{a RaMP database object}
 }

--- a/man/getOntoFromMeta.Rd
+++ b/man/getOntoFromMeta.Rd
@@ -5,7 +5,14 @@
 \title{Function that query database to find ontology information based on
 the given list of metabolites}
 \usage{
-getOntoFromMeta(mets, namesOrIds = "ids", includeRaMPids = FALSE, db = RaMP())
+getOntoFromMeta(
+  mets,
+  namesOrIds = "ids",
+  includeRaMPids = FALSE,
+  min_ontology_size = 1000,
+  max_ontology_size = Inf,
+  db = RaMP()
+)
 }
 \arguments{
 \item{mets}{a vector of metabolites or a metabolites delimited by new line character}
@@ -13,6 +20,10 @@ getOntoFromMeta(mets, namesOrIds = "ids", includeRaMPids = FALSE, db = RaMP())
 \item{namesOrIds}{specify the type of given data}
 
 \item{includeRaMPids}{whether or not to include RaMP ids in the output (TRUE/FALSE)}
+
+\item{min_ontology_size}{the minimum number of metabolites in an ontology for it to be included in results. Default is 1,000}
+
+\item{max_ontology_size}{the maximum number of metabolites in an ontology for it to be included in results. Default is Inf}
 
 \item{db}{a RaMP database object}
 }


### PR DESCRIPTION
The objective is to handle the several ontologies which are not useful and may be confusing. The ontology fisher test already handles this by setting a min and max limit on the number of metabolites in an ontology to be included in testing, and so I extended this to getOntoFromMeta and getMetaFromOnto. 

For use in the front end, I also made a list of the ontology terms HMDB lets a user filter results by on their website, and added a "curate"  parameter to filter results to only these in getMetaFromOnto. I anticipate this feature will be primarily used by the front-end to make the UI as user friendly as possible.

My thinking on splitting the handling like this is to maximize flexibility and interpret-ability for users of the R package while keeping the UI as user friendly as possible. 