### PR TITLE
Updates to Reaction Functions:

### DIFF
--- a/R/rampQueryHelper.R
+++ b/R/rampQueryHelper.R
@@ -1088,7 +1088,7 @@ buildReactionClassesSunburstDataframe <- function(reactionClassesResults) {
 buildAnalyteOverlapPerRxnLevelUpsetDataframe <- function(reactionsResults, includeCofactorMets = FALSE) {
   if(nrow(reactionsResults$met2rxn)>0)
   {
-    met2rxn_EC <- reactionsResults$met2rxn %>% dplyr::filter(!dplyr::if_any(.data$ecNumber, is.na))
+    met2rxn_EC <- reactionsResults$met2rxn %>% dplyr::filter(!dplyr::if_any("ecNumber", is.na))
     if(nrow(met2rxn_EC)>0)
     {
       EC_number_split_met <- unlist(strsplit(met2rxn_EC$ecNumber,split="\\."))
@@ -1097,17 +1097,19 @@ buildAnalyteOverlapPerRxnLevelUpsetDataframe <- function(reactionsResults, inclu
         c(met2rxn_EC$ecNumber),
         c(paste0(EC_number_split_met[seq(1, length(EC_number_split_met), 4)]))
       )
+
+
     }
 
-    met2rxn_NoEC <- reactionsResults$met2rxn %>% dplyr::filter(dplyr::if_any(.data$ecNumber, is.na))
+    met2rxn_NoEC <- reactionsResults$met2rxn %>% dplyr::filter(dplyr::if_any("ecNumber", is.na))
   }
   if (includeCofactorMets == FALSE)
   {
-    met2rxn_EC <- met2rxn_EC %>% dplyr::filter(.data$isCofactor == 0)
+    met2rxn_EC <- met2rxn_EC %>% dplyr::filter("isCofactor" == 0)
   }
   if(nrow(reactionsResults$prot2rxn)>0)
   {
-    prot2rxn_EC <- reactionsResults$prot2rxn %>% dplyr::filter(!dplyr::if_any(.data$ecNumber, is.na))
+    prot2rxn_EC <- reactionsResults$prot2rxn %>% dplyr::filter(!dplyr::if_any("ecNumber", is.na))
     if(nrow(prot2rxn_EC)>0)
     {
       EC_number_split_prot <- unlist(strsplit(prot2rxn_EC$ecNumber,split="\\."))
@@ -1118,7 +1120,7 @@ buildAnalyteOverlapPerRxnLevelUpsetDataframe <- function(reactionsResults, inclu
       )
     }
 
-    prot2rxn_NoEC <- reactionsResults$prot2rxn %>% dplyr::filter(dplyr::if_any(.data$ecNumber, is.na))
+    prot2rxn_NoEC <- reactionsResults$prot2rxn %>% dplyr::filter(dplyr::if_any("ecNumber", is.na))
   }
 
   if(exists("input2reactions_mets") && exists("input2reactions_prot"))
@@ -1192,6 +1194,15 @@ buildAnalyteOverlapPerRxnLevelUpsetDataframe <- function(reactionsResults, inclu
   }
 
   input2reactions_list$"Non-Enzymatic" <- NoEC
+
+  for (i in 1:length(input2reactions_list))
+  {
+    if (is.null(input2reactions_list[[i]]) == TRUE)
+    {
+      next
+    } else
+    {input2reactions_list[[i]] <- unlist(strsplit(input2reactions_list[[i]], "[|]"))}
+  }
 
   return(input2reactions_list)
 }

--- a/man/runReactionClassTest.Rd
+++ b/man/runReactionClassTest.Rd
@@ -13,7 +13,7 @@ runReactionClassTest(
 )
 }
 \arguments{
-\item{analytes}{a vector of analyte ids (genes or metabolites) that need to be searched}
+\item{analytes}{a vector of analyte ids (genes or metabolites) that need to be searched. ID types accepted: chebi and uniprot}
 
 \item{humanProtein}{require reactions to have a human protein (enzyme or transporter), default True}
 

--- a/tests/testthat/test-reaction_query_test.R
+++ b/tests/testthat/test-reaction_query_test.R
@@ -21,7 +21,7 @@ test_that("test_mixed_analyte_reaction_query", {
 
   # rampDB has been already been instantiated in helper-setup..
   rxns = RaMP::getReactionsForAnalytes(db=rampDB, analytes=analytes, humanProtein = T)
-  expect_true(nrow(rxns$met2rxn) > 150)
+  expect_true(nrow(rxns$met2rxn) > 100)
   expect_true(nrow(rxns$prot2rxn) > 15)
   expect_true(nrow(rxns$metProteinCommonReactions) > 3)
 
@@ -45,7 +45,7 @@ test_that("test_metabolite_reaction_query", {
 
   # rampDB has been already been instantiated in helper-setup..
   rxns = RaMP::getReactionsForAnalytes(db=rampDB, analytes=mets, humanProtein = T)
-  expect_true(nrow(rxns$met2rxn) > 150)
+  expect_true(nrow(rxns$met2rxn) > 100)
   expect_true(is.null(nrow(rxns$protein2rxn)))
 
 })


### PR DESCRIPTION
- fix for runReactionClassTest to only take in chebi/uniprot ids

- reformatting the output of the getReactionsForAnalytes() function such that there is one line per function (e.g. grouping by reaction id)

- subsequent fix to buildAnalyteOverlapPerRxnLevelUpsetDataframe() to handle new input for upset plot

- subsequent fix to test-reaction_query_test to handle shortened output from getReactionsForAnalytes()