### PR TITLE
Ramp3.0 fixes

### DIFF
--- a/R/OntologyQueryFunctions.R
+++ b/R/OntologyQueryFunctions.R
@@ -424,7 +424,7 @@ runEnrichOntologies <- function(mets,
     ontologyid <- x["rampOntologyId"]
     sigontologydf <- ontologydf[which(ontologydf$rampOntologyId == ontologyid), ]
     analytes <- sigontologydf[, "Metabolites"] %>%
-      paste0(collapse = "|")
+      paste0(collapse = " | ")
     return(analytes)
   })
 

--- a/R/ReturnPathwaysEnrich_InputAnalytes.R
+++ b/R/ReturnPathwaysEnrich_InputAnalytes.R
@@ -580,7 +580,7 @@ runEnrichPathways <- function(
     pathwayid <- x["pathwayRampId"]
     sigpathwaydf <- pathwaydf[which(pathwaydf$pathwayRampId == pathwayid), ]
     analytes <- sigpathwaydf[, "commonName"] %>%
-      paste0(collapse = "|")  # KJK - changed semicolon to pipe, since lipids sometimes have ';' in the name
+      paste0(collapse = " | ")  # KJK - added a space for formatting
     return(analytes)
   })
   if (includeRaMPids) {

--- a/R/rampReactionQueries.R
+++ b/R/rampReactionQueries.R
@@ -159,8 +159,8 @@ getReactionsForAnalytes <- function( analytes, onlyHumanMets=F, humanProtein=T, 
 
     for (i in 1:length(met2rxn_edit))
     {
-      metSourceId <- paste0(c(met2rxn_edit[[i]]$metSourceId), collapse = "|")
-      metName <- paste0(c(met2rxn_edit[[i]]$metName), collapse = "|")
+      metSourceId <- paste0(c(met2rxn_edit[[i]]$metSourceId), collapse = " | ")
+      metName <- paste0(c(met2rxn_edit[[i]]$metName), collapse = " | ")
       line2add <- met2rxn_edit[[i]][1,]
       line2add$metSourceId <- metSourceId
       line2add$metName <- metName
@@ -180,8 +180,8 @@ getReactionsForAnalytes <- function( analytes, onlyHumanMets=F, humanProtein=T, 
 
     for (i in 1:length(prot2rxn_edit))
     {
-      uniprot <- paste0(c(prot2rxn_edit[[i]]$uniprot), collapse = "|")
-      proteinName <- paste0(c(prot2rxn_edit[[i]]$proteinName), collapse = "|")
+      uniprot <- paste0(c(prot2rxn_edit[[i]]$uniprot), collapse = " | ")
+      proteinName <- paste0(c(prot2rxn_edit[[i]]$proteinName), collapse = " | ")
       line2add <- prot2rxn_edit[[i]][1,]
       line2add$uniprot <- uniprot
       line2add$proteinName <- proteinName

--- a/db/RaMP_SQLite_v3.0.4.sqlite.gz
+++ b/db/RaMP_SQLite_v3.0.4.sqlite.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd827c15ab9d0ae872230b6ea304da41e0a559f2c8e527c66c49c037b7a5bcd7
-size 522563663

--- a/db/RaMP_SQLite_v3.0.5.sqlite.gz
+++ b/db/RaMP_SQLite_v3.0.5.sqlite.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83997b8438c9318efa5d39250f726ecb59bce6a9eb942c7ae218570b50ea950a
+size 522561003

--- a/db/RaMP_SQLite_v3.0.5.sqlite.gz
+++ b/db/RaMP_SQLite_v3.0.5.sqlite.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:83997b8438c9318efa5d39250f726ecb59bce6a9eb942c7ae218570b50ea950a
-size 522561003

--- a/db/RaMP_SQLite_v3.0.6.sqlite.gz
+++ b/db/RaMP_SQLite_v3.0.6.sqlite.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4c8f09294a6916246911a55c3f901c460b4c57cee79ced8aa873dfb81812049
+size 522563573


### PR DESCRIPTION
add reaction counts to database
update pipe delimiters to have spaces for readability